### PR TITLE
fix(auth): add email length validation and map error to 400 Bad Request

### DIFF
--- a/internal/handler/register_test.go
+++ b/internal/handler/register_test.go
@@ -1,0 +1,41 @@
+package handler
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/herdifirdausss/belajar-vibe-coding/internal/service"
+)
+
+func TestUserHandler_RegisterUserHandler_EmailLength(t *testing.T) {
+	// We need to pass a service that will return the error we want.
+	// Since we are testing the handler's mapping of the error from the service,
+	// we can use a real service but with nil repositories, because the validation happens BEFORE repo calls.
+	svc := service.NewUserService(nil, nil)
+	h := NewUserHandler(svc)
+
+	// Test case: email 256 characters
+	email256 := strings.Repeat("a", 247) + "@test.com"
+	reqBody, _ := json.Marshal(RegisterRequest{
+		Email:    email256,
+		Password: "password123",
+	})
+
+	req, _ := http.NewRequest(http.MethodPost, "/register", bytes.NewBuffer(reqBody))
+	rr := httptest.NewRecorder()
+
+	h.RegisterUserHandler(rr, req)
+
+	if status := rr.Code; status != http.StatusBadRequest {
+		t.Errorf("handler returned wrong status code: got %v want %v", status, http.StatusBadRequest)
+	}
+
+	expected := `{"error":"email must not exceed 255 characters"}`
+	if strings.TrimSpace(rr.Body.String()) != expected {
+		t.Errorf("handler returned unexpected body: got %v want %v", rr.Body.String(), expected)
+	}
+}

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"encoding/json"
+	"errors"
 	"net/http"
 
 	"github.com/herdifirdausss/belajar-vibe-coding/internal/models"
@@ -38,7 +39,7 @@ func (h *UserHandler) RegisterUserHandler(w http.ResponseWriter, r *http.Request
 	user, err := h.svc.Register(req.Email, req.Password)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if err.Error() == "invalid email format" || err.Error() == "email must not exceed 255 characters" || err.Error() == "password must be at least 8 characters long" {
+		if errors.Is(err, service.ErrInvalidEmailFormat) || errors.Is(err, service.ErrEmailTooLong) || errors.Is(err, service.ErrPasswordTooShort) {
 			status = http.StatusBadRequest
 		}
 
@@ -71,9 +72,11 @@ func (h *UserHandler) LoginHandler(w http.ResponseWriter, r *http.Request) {
 
 	token, err := h.svc.Login(req.Email, req.Password)
 	if err != nil {
-		status := http.StatusUnauthorized
-		if err.Error() == "invalid email format" || err.Error() == "email and password are required" {
+		status := http.StatusInternalServerError
+		if errors.Is(err, service.ErrInvalidEmailFormat) || errors.Is(err, service.ErrEmailOrPasswordMissing) {
 			status = http.StatusBadRequest
+		} else if errors.Is(err, service.ErrInvalidCredentials) {
+			status = http.StatusUnauthorized
 		}
 
 		w.Header().Set("Content-Type", "application/json")
@@ -110,7 +113,7 @@ func (h *UserHandler) GetMe(w http.ResponseWriter, r *http.Request) {
 	user, err := h.svc.Me(token)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if err.Error() == "unauthorized" {
+		if errors.Is(err, service.ErrUnauthorized) {
 			status = http.StatusUnauthorized
 		}
 
@@ -150,7 +153,7 @@ func (h *UserHandler) LogoutHandler(w http.ResponseWriter, r *http.Request) {
 	err := h.svc.Logout(token)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if err.Error() == "unauthorized" {
+		if errors.Is(err, service.ErrUnauthorized) {
 			status = http.StatusUnauthorized
 		}
 

--- a/internal/handler/user_handler.go
+++ b/internal/handler/user_handler.go
@@ -38,7 +38,7 @@ func (h *UserHandler) RegisterUserHandler(w http.ResponseWriter, r *http.Request
 	user, err := h.svc.Register(req.Email, req.Password)
 	if err != nil {
 		status := http.StatusInternalServerError
-		if err.Error() == "invalid email format" || err.Error() == "password must be at least 8 characters long" {
+		if err.Error() == "invalid email format" || err.Error() == "email must not exceed 255 characters" || err.Error() == "password must be at least 8 characters long" {
 			status = http.StatusBadRequest
 		}
 

--- a/internal/service/register_test.go
+++ b/internal/service/register_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"strings"
 	"testing"
 )
@@ -15,8 +16,8 @@ func TestUserService_Register_EmailLength(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for email length 256, but got nil")
 	}
-	if err.Error() != "email must not exceed 255 characters" {
-		t.Errorf("expected error 'email must not exceed 255 characters', but got: %v", err)
+	if !errors.Is(err, ErrEmailTooLong) {
+		t.Errorf("expected ErrEmailTooLong, but got: %v", err)
 	}
 
 	// Test case: invalid email format
@@ -24,7 +25,7 @@ func TestUserService_Register_EmailLength(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for invalid email format, but got nil")
 	}
-	if err.Error() != "invalid email format" {
-		t.Errorf("expected error 'invalid email format', but got: %v", err)
+	if !errors.Is(err, ErrInvalidEmailFormat) {
+		t.Errorf("expected ErrInvalidEmailFormat, but got: %v", err)
 	}
 }

--- a/internal/service/register_test.go
+++ b/internal/service/register_test.go
@@ -1,0 +1,30 @@
+package service
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUserService_Register_EmailLength(t *testing.T) {
+	svc := &UserService{}
+
+	// Test case: email 256 characters
+	// This should return an error BEFORE calling the repository.
+	email256 := strings.Repeat("a", 247) + "@test.com"
+	_, err := svc.Register(email256, "password123")
+	if err == nil {
+		t.Fatal("expected error for email length 256, but got nil")
+	}
+	if err.Error() != "email must not exceed 255 characters" {
+		t.Errorf("expected error 'email must not exceed 255 characters', but got: %v", err)
+	}
+
+	// Test case: invalid email format
+	_, err = svc.Register("invalid-email", "password123")
+	if err == nil {
+		t.Fatal("expected error for invalid email format, but got nil")
+	}
+	if err.Error() != "invalid email format" {
+		t.Errorf("expected error 'invalid email format', but got: %v", err)
+	}
+}

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -14,6 +14,15 @@ import (
 	"golang.org/x/crypto/argon2"
 )
 
+var (
+	ErrInvalidEmailFormat     = errors.New("invalid email format")
+	ErrEmailTooLong           = errors.New("email must not exceed 255 characters")
+	ErrPasswordTooShort       = errors.New("password must be at least 8 characters long")
+	ErrEmailOrPasswordMissing = errors.New("email and password are required")
+	ErrInvalidCredentials     = errors.New("email or password incorrect")
+	ErrUnauthorized           = errors.New("unauthorized")
+)
+
 type UserService struct {
 	userRepo    *repository.UserRepository
 	sessionRepo *repository.SessionRepository
@@ -27,17 +36,17 @@ func (s *UserService) Register(email, password string) (*models.User, error) {
 	// 1. Validate email
 	_, err := mail.ParseAddress(email)
 	if err != nil {
-		return nil, errors.New("invalid email format")
+		return nil, ErrInvalidEmailFormat
 	}
 
 	// 1.b Validate email length
 	if len(email) > 255 {
-		return nil, errors.New("email must not exceed 255 characters")
+		return nil, ErrEmailTooLong
 	}
 
 	// 2. Validate password
 	if len(password) < 8 {
-		return nil, errors.New("password must be at least 8 characters long")
+		return nil, ErrPasswordTooShort
 	}
 
 	// 3. Hash password
@@ -63,12 +72,12 @@ func (s *UserService) Register(email, password string) (*models.User, error) {
 func (s *UserService) Login(email, password string) (*string, error) {
 	// 1. Validate input
 	if email == "" || password == "" {
-		return nil, errors.New("email and password are required")
+		return nil, ErrEmailOrPasswordMissing
 	}
 
 	_, err := mail.ParseAddress(email)
 	if err != nil {
-		return nil, errors.New("invalid email format")
+		return nil, ErrInvalidEmailFormat
 	}
 
 	// 2. Find user by email
@@ -78,7 +87,7 @@ func (s *UserService) Login(email, password string) (*string, error) {
 	}
 
 	if user == nil {
-		return nil, errors.New("email or password incorrect")
+		return nil, ErrInvalidCredentials
 	}
 
 	// 3. Compare password
@@ -88,7 +97,7 @@ func (s *UserService) Login(email, password string) (*string, error) {
 	}
 
 	if !match {
-		return nil, errors.New("email or password incorrect")
+		return nil, ErrInvalidCredentials
 	}
 
 	// 4. Generate token
@@ -112,7 +121,7 @@ func (s *UserService) Login(email, password string) (*string, error) {
 
 func (s *UserService) Me(token string) (*models.User, error) {
 	if token == "" {
-		return nil, errors.New("unauthorized")
+		return nil, ErrUnauthorized
 	}
 
 	user, err := s.userRepo.FindByToken(token)
@@ -121,7 +130,7 @@ func (s *UserService) Me(token string) (*models.User, error) {
 	}
 
 	if user == nil {
-		return nil, errors.New("unauthorized")
+		return nil, ErrUnauthorized
 	}
 
 	return user, nil
@@ -129,7 +138,7 @@ func (s *UserService) Me(token string) (*models.User, error) {
 
 func (s *UserService) Logout(token string) error {
 	if token == "" {
-		return errors.New("unauthorized")
+		return ErrUnauthorized
 	}
 
 	return s.sessionRepo.DeleteByToken(token)

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -30,6 +30,11 @@ func (s *UserService) Register(email, password string) (*models.User, error) {
 		return nil, errors.New("invalid email format")
 	}
 
+	// 1.b Validate email length
+	if len(email) > 255 {
+		return nil, errors.New("email must not exceed 255 characters")
+	}
+
 	// 2. Validate password
 	if len(password) < 8 {
 		return nil, errors.New("password must be at least 8 characters long")


### PR DESCRIPTION
Fixes #11. This PR adds email length validation in the service layer and ensure the handler returns 400 Bad Request instead of exposing raw SQL errors.